### PR TITLE
Added an email field to the auth hash

### DIFF
--- a/lib/omniauth/strategies/pam.rb
+++ b/lib/omniauth/strategies/pam.rb
@@ -49,7 +49,7 @@ module OmniAuth
         {
           :nickname => uid,
           :name => uid,
-          :email => "#{uid}@uno.edu"
+          :email => "#{uid}#{ options[:email].present? ? options[:email] : ''}"
         }.merge!(parse_gecos)
       end
     end


### PR DESCRIPTION
Adding an email field and option. This allows some other programs to use this gem similarly to those that are based on Oauth. Gitlab for example has a sign sign on mode, but expects an email field in the returned hash.
