### PR TITLE
use rpam2, cleanup

### DIFF
--- a/lib/omniauth/pam.rb
+++ b/lib/omniauth/pam.rb
@@ -1,6 +1,5 @@
 require "omniauth"
-require "rpam"
-require "etc"
+require "rpam2"
 
 module OmniAuth
   module Strategies

--- a/omniauth-pam.gemspec
+++ b/omniauth-pam.gemspec
@@ -18,9 +18,8 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(/^(test|spec|features)/)
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency "omniauth", "~> 1.5"
-  s.add_runtime_dependency 'rpam-ruby19', '~> 1.2.1'
-  s.add_runtime_dependency 'etc'
+  s.add_runtime_dependency 'omniauth', '~> 1.5'
+  s.add_runtime_dependency 'rpam2', '~> 4.0'
 
   s.add_development_dependency "pry"
   s.add_development_dependency "rack-test"

--- a/spec/omniauth/strategies/pam_spec.rb
+++ b/spec/omniauth/strategies/pam_spec.rb
@@ -1,6 +1,22 @@
 require "spec_helper"
 
+
+
 describe OmniAuth::Strategies::PAM do
+  before(:all) do
+    Rpam2.fake_data =
+      {
+        usernames: Set['authur'],
+        servicenames: Set['rpam', nil],
+        password: 'a_password',
+        env:
+          {
+            email: 'me@example.com',
+            name: 'Authur Dent'
+          }
+      }
+  end
+
   describe "#request_phase" do
     it "displays a form" do
       get "/auth/pam"
@@ -13,7 +29,6 @@ describe OmniAuth::Strategies::PAM do
     context "with valid credentials" do
       it "populates the auth hash" do
         mock_rpam(valid_credentials.merge(opts: {})).and_return(true)
-        mock_etc
 
         post "/auth/pam/callback", valid_credentials
 
@@ -63,17 +78,11 @@ describe OmniAuth::Strategies::PAM do
   end
 
   def mock_rpam(username:, password:, opts:)
-    allow(Rpam).to receive(:auth).with(username, password, opts)
+    allow(Rpam2).to receive(:auth).with(opts[:service], username, password)
   end
 
   def expect_rpam_to_be_called(username:, password:, opts: {})
-    expect(Rpam).to have_received(:auth).with(username, password, opts)
+    expect(Rpam2).to have_received(:auth).with(opts[:service], username, password)
   end
 
-  def mock_etc
-    etc_struct = Etc::Passwd.new
-    etc_struct.gecos = "Authur Dent,,"
-
-    expect(Etc).to receive(:getpwnam).with("authur").and_return(etc_struct)
-  end
 end

--- a/spec/omniauth/strategies/pam_spec.rb
+++ b/spec/omniauth/strategies/pam_spec.rb
@@ -26,20 +26,17 @@ describe OmniAuth::Strategies::PAM do
   describe "#callback_phase" do
     context "with valid credentials" do
       it "populates the auth hash" do
-        mock_rpam(valid_credentials.merge(opts: {})).and_return(true)
 
         post "/auth/pam/callback", valid_credentials
 
         expect(auth_hash["provider"]).to eq("pam")
         expect(auth_hash["uid"]).to eq("authur")
         expect(auth_hash["info"]["name"]).to eq("Authur Dent")
-        expect_rpam_to_be_called(valid_credentials.merge(opts: {}))
       end
     end
 
     context "with invalid credentials" do
       it "redirects to /auth/failure" do
-        mock_rpam(invalid_credentials.merge(opts: {}))
 
         post "/auth/pam/callback", invalid_credentials
 
@@ -47,7 +44,6 @@ describe OmniAuth::Strategies::PAM do
         expect(last_response.headers["Location"]).to eq(
           "/auth/failure?message=invalid_credentials&strategy=pam",
         )
-        expect_rpam_to_be_called(invalid_credentials.merge(opts: {}))
       end
     end
   end
@@ -73,15 +69,6 @@ describe OmniAuth::Strategies::PAM do
 
   def invalid_credentials
     { username: "not_a_valid_user", password: "not_a_valid_password" }
-  end
-
-  def mock_rpam(username:, password:, opts:)
-    allow(Rpam2).to receive(:auth).with(opts[:service], username, password)
-  end
-
-  def expect_rpam_to_be_called(username:, password:, opts: {})
-    expect(Rpam2).to \
-      have_received(:auth).with(opts[:service], username, password)
   end
 
 end

--- a/spec/omniauth/strategies/pam_spec.rb
+++ b/spec/omniauth/strategies/pam_spec.rb
@@ -1,19 +1,17 @@
 require "spec_helper"
 
-
-
 describe OmniAuth::Strategies::PAM do
   before(:all) do
     Rpam2.fake_data =
       {
-        usernames: Set['authur'],
-        servicenames: Set['rpam', nil],
-        password: 'a_password',
+        usernames: Set["authur"],
+        servicenames: Set["rpam", nil],
+        password: "a_password",
         env:
           {
-            email: 'me@example.com',
-            name: 'Authur Dent'
-          }
+            email: "me@example.com",
+            name: "Authur Dent",
+          },
       }
   end
 
@@ -82,7 +80,9 @@ describe OmniAuth::Strategies::PAM do
   end
 
   def expect_rpam_to_be_called(username:, password:, opts: {})
-    expect(Rpam2).to have_received(:auth).with(opts[:service], username, password)
+    expect(Rpam2).to(
+        have_received(:auth).with(opts[:service], username, password),
+      )
   end
 
 end

--- a/spec/omniauth/strategies/pam_spec.rb
+++ b/spec/omniauth/strategies/pam_spec.rb
@@ -80,9 +80,8 @@ describe OmniAuth::Strategies::PAM do
   end
 
   def expect_rpam_to_be_called(username:, password:, opts: {})
-    expect(Rpam2).to(
-        have_received(:auth).with(opts[:service], username, password),
-      )
+    expect(Rpam2).to \
+      have_received(:auth).with(opts[:service], username, password)
   end
 
 end


### PR DESCRIPTION
* Switch application to use rpam2
* Use listenv feature of rpam2 to get email and other possible variables. This works only if the pam environment is populated; one other project of mine (anyway it is very easy to populate and could integrate remote data in contrast to Etc)
* some code cleanup
* update dependencies to safe defaults (after last omniauth security fixes)