### PR TITLE
ignore vendor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .bundle
 Gemfile.lock
 pkg/*
+vendor


### PR DESCRIPTION
ignore vendor. This prevents an accidentally commit of the ruby vendor folder.