### PR TITLE
Add tests.

### DIFF
--- a/lib/omniauth-pam.rb
+++ b/lib/omniauth-pam.rb
@@ -1,7 +1,2 @@
-# depends upon rpam and etc
-require "rpam"
-require "etc"
-
-# then the rest of the strategy
 require "omniauth-pam/version"
-require "omniauth/strategies/pam"
+require "omniauth/pam"

--- a/lib/omniauth/pam.rb
+++ b/lib/omniauth/pam.rb
@@ -1,0 +1,9 @@
+require "omniauth"
+require "rpam"
+require "etc"
+
+module OmniAuth
+  module Strategies
+    autoload :PAM, "omniauth/strategies/pam"
+  end
+end

--- a/omniauth-pam.gemspec
+++ b/omniauth-pam.gemspec
@@ -1,5 +1,6 @@
-# encoding: UTF-8
-require File.expand_path('../lib/omniauth-pam/version', __FILE__)
+$:.push File.expand_path("lib", __dir__)
+
+require "omniauth-pam/version"
 
 Gem::Specification.new do |s|
   s.name        = 'omniauth-pam'
@@ -22,4 +23,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'omniauth', '~> 1.0'
   s.add_runtime_dependency 'rpam-ruby19', '~> 1.2.1'
   s.add_runtime_dependency 'etc'
+
+  s.add_development_dependency "pry"
+  s.add_development_dependency "rack-test"
+  s.add_development_dependency "rspec"
 end

--- a/spec/omniauth/strategies/pam_spec.rb
+++ b/spec/omniauth/strategies/pam_spec.rb
@@ -1,0 +1,79 @@
+require "spec_helper"
+
+describe OmniAuth::Strategies::PAM do
+  describe "#request_phase" do
+    it "displays a form" do
+      get "/auth/pam"
+
+      expect(last_response.body).to include("<form")
+    end
+  end
+
+  describe "#callback_phase" do
+    context "with valid credentials" do
+      it "populates the auth hash" do
+        mock_rpam(valid_credentials.merge(opts: {})).and_return(true)
+        mock_etc
+
+        post "/auth/pam/callback", valid_credentials
+
+        expect(auth_hash["provider"]).to eq("pam")
+        expect(auth_hash["uid"]).to eq("authur")
+        expect(auth_hash["info"]["name"]).to eq("Authur Dent")
+        expect_rpam_to_be_called(valid_credentials.merge(opts: {}))
+      end
+    end
+
+    context "with invalid credentials" do
+      it "redirects to /auth/failure" do
+        mock_rpam(invalid_credentials.merge(opts: {}))
+
+        post "/auth/pam/callback", invalid_credentials
+
+        expect(last_response).to be_redirect
+        expect(last_response.headers["Location"]).to eq(
+          "/auth/failure?message=invalid_credentials&strategy=pam",
+        )
+        expect_rpam_to_be_called(invalid_credentials.merge(opts: {}))
+      end
+    end
+  end
+
+  private
+
+  def app
+    Rack::Builder.new do
+      use Rack::Session::Cookie, secret: "xyz"
+      use OmniAuth::Strategies::PAM
+
+      run lambda { |env| [404, { "env" => env }, ["PAM Strategy App"]] }
+    end.to_app
+  end
+
+  def auth_hash
+    last_response.headers["env"]["omniauth.auth"]
+  end
+
+  def valid_credentials
+    { username: "authur", password: "a_password" }
+  end
+
+  def invalid_credentials
+    { username: "not_a_valid_user", password: "not_a_valid_password" }
+  end
+
+  def mock_rpam(username:, password:, opts:)
+    allow(Rpam).to receive(:auth).with(username, password, opts)
+  end
+
+  def expect_rpam_to_be_called(username:, password:, opts: {})
+    expect(Rpam).to have_received(:auth).with(username, password, opts)
+  end
+
+  def mock_etc
+    etc_struct = Etc::Passwd.new
+    etc_struct.gecos = "Authur Dent,,"
+
+    expect(Etc).to receive(:getpwnam).with("authur").and_return(etc_struct)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,9 @@
+require "bundler"
+Bundler.setup :default, :development, :test
+
+require "rack/test"
+require "omniauth/pam"
+
+RSpec.configure do |config|
+  config.include Rack::Test::Methods
+end


### PR DESCRIPTION
* Aims to cover the interaction between PAM + OmniAuth.
* Mocks `rpam`, `etc` to allow it to run without directly
  authenticating.
* Reworks the class loading such that the test paths can be simplified,
  and it behave similar to `omniauth-identity`.